### PR TITLE
Hide password for dev artifactory user

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 		maven { 
 		  credentials {
             	username "$repoUser"
-            	password "$repoPassword"
+            	password System.env.REPO_RO_PASSWD
         	}
 			url "${mavenRepoBaseUrl}/repo" 
 		}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 mavenRepoBaseUrl=https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga
 org.gradle.caching=false
 repoUser=dev
-repoPassword=dev1234


### PR DESCRIPTION
 The Artifactory Read-only User Password is available as Environment Variable: REPO_RO_PASSWD, instead of property value. It is evaluated at Build time resp. Runtime . Developers need to add this Variable to their enviroments.
In Jenkins it is configured as "Globale Eigentschaft", see https://jenkins.apgsga.ch/configure